### PR TITLE
Feature/final document label confirmation

### DIFF
--- a/backend/api/document_api.py
+++ b/backend/api/document_api.py
@@ -226,6 +226,76 @@ def set_label_for_user(project_name, document_id):
     return '', 204
 
 
+@document_api.route('/projects/<project_name>/documents/<document_id>/label-agreement', methods=['POST'])
+def set_final_label_after_agreement(project_name, document_id):
+    id_token = request.args.get('id_token')
+
+    if id_token is None or id_token == "":
+        response = {'message': "ID Token is not included with the request uri in args"}
+        response = make_response(response)
+        return response, 400
+
+    requestor_email = get_email(id_token)
+
+    if requestor_email is None:
+        response = {'message': "ID Token has expired or is invalid"}
+        response = make_response(response)
+        return response, 400
+
+    # get user obj
+    user_col = get_db_collection(project_name, "users")
+    requestor = user_col.find_one({'email': requestor_email, 'isContributor': True})
+    if requestor is None:
+        response = {'message': "You are not authorised to perform this action"}
+        response = make_response(response)
+        return response, 403
+
+    if 'label_id' in request.json:
+        label_id = request.json['label_id']
+    else:
+        response = {'message': "Missing label"}
+        response = make_response(response)
+        return response, 400
+
+    label_col = get_db_collection(project_name, "labels")
+    label = label_col.find_one({'_id': ObjectId(label_id)})
+    if label is None:
+        response = {'message': "Invalid Label"}
+        response = make_response(response)
+        return response, 400
+
+    doc_col = get_db_collection(project_name, "documents")
+    doc = doc_col.find_one({'_id': ObjectId(document_id)})
+    # check for doc existing
+    if doc is None:
+        response = {'message': "Invalid Document"}
+        response = make_response(response)
+        return response, 400
+
+    # check that doc is fully labelled
+    if len(doc['user_and_labels']) < 2:
+        response = {'message': "Labelling for document incomplete!"}
+        response = make_response(response)
+        return response, 400
+
+    # check for labelling confirmed
+    if doc['label_confirmed']:
+        response = {'message': "Label already confirmed!"}
+        response = make_response(response)
+        return response, 400
+
+    # Confirm label is final and set labels for users
+    for user_label in doc['user_and_labels']:
+        doc_col.update_one({'_id': ObjectId(document_id),
+                            "user_and_labels": {'$elemMatch': {"email": user_label['email']}}},
+                           {'$set': {
+                               "user_and_labels.$.label": ObjectId(label_id),
+                               "label_confirmed": True}
+                           })
+
+    return '', 200
+
+
 @document_api.route('/projects/<project_name>/unlabelled/documents', methods=['Get'])
 def get_unlabelled_document_ids(project_name):
     id_token = request.args.get('id_token')

--- a/backend/model/document.py
+++ b/backend/model/document.py
@@ -14,6 +14,7 @@ class Document:
         self.data = data
         self.comments = comments
         self.user_and_labels = user_and_labels
+        self.label_confirmed = False
 
     def upload(self, project_name):
         col = get_db_collection(project_name, "documents")


### PR DESCRIPTION
#### Description
Added endpoint for confirming and setting final agreed label

N.B. Because the domain model for document has changed, existing documents in databases should be dropped and re-inserted (via the upload function) OR add a boolean `'label_confirmed'` field to the documents (see `testupload` db for example)

#### Review Checklist
- [x] The requirements on the description have been met
- [x] The relevant documentation has been updated:
    - [ ] code comments for classes / methods / complex statements
    - [ ] package readme
    - [ ] documentation for high level approaches or product info
- [x] Tests:
    - [ ] new tests written
    - [ ] existing affected tests updated
    - [ ] all green and passing
- [ ] Tested by reviewer
