### PR TITLE
bugfix/permission_displayed

### DIFF
--- a/app/src/components/SettingsUser.tsx
+++ b/app/src/components/SettingsUser.tsx
@@ -29,6 +29,13 @@ const SettingsUser: React.FC<ContainerProps> = ({ project, user, isContributor, 
   const refContributor = useRef(localIsContributor)
   const refAdmin = useRef(localIsAdmin)
 
+  useEffect(() => {
+    setLocalIsContributor(isContributor)
+  }, [isContributor])
+
+  useEffect(() => {
+    setLocalIsAdmin(isAdmin)
+  }, [isAdmin])
 
   const alert = 
   <IonAlert


### PR DESCRIPTION
#### Description
hook prop changes into the state.
using state in low component is not recommended, but this works for now

#### Review Checklist
- [ ] The requirements on the description have been met
- [ ] The relevant documentation has been updated:
    - [ ] code comments for classes / methods / complex statements
    - [ ] package readme
    - [ ] documentation for high level approaches or product info
- [ ] Tests:
    - [ ] new tests written
    - [ ] existing affected tests updated
    - [ ] all green and passing
- [ ] Tested by reviewer
