### PR TITLE
bugfix/correct-label-confirmation-and-final-label-when-setting-label

### DIFF
--- a/backend/api/methods.py
+++ b/backend/api/methods.py
@@ -55,17 +55,26 @@ def update_user_document_label(col, email, document_id, label_id, labels_are_mat
                        })
 
 
-def create_user_document_label(col, email, document_id, label_id):
-    col.update_one({'_id': ObjectId(document_id)},
-                   {'$push': {
-                       "user_and_labels": {
-                           "email": email,
-                           "label": ObjectId(label_id),
-                           "label_confirmed": False}
-                   },
-                       '$set': {"final_label": None}}
-                   )
-
+def create_user_document_label(col, email, document_id, label_id, labels_are_match):
+    if labels_are_match:
+        col.update_one({'_id': ObjectId(document_id)},
+                       {'$push': {
+                           "user_and_labels": {
+                               "email": email,
+                               "label": ObjectId(label_id),
+                               "label_confirmed": labels_are_match}
+                       },
+                           '$set': {"final_label": ObjectId(label_id)}}
+                       )
+    else:
+        col.update_one({'_id': ObjectId(document_id)},
+                       {'$push': {
+                           "user_and_labels": {
+                               "email": email,
+                               "label": ObjectId(label_id),
+                               "label_confirmed": labels_are_match}
+                       }
+                       })
 
 def check_all_labels_for_document_match(document):
     user_and_labels = document['user_and_labels']


### PR DESCRIPTION
#### Description
Fixed issue where the 'final_label' and 'label_confirmed' fields weren't set correctly.

This issue appeared when one contributor had already labelled the document, and the second contributor's initial labelling agreed with the first contributor.

#### Review Checklist
- [ ] The requirements on the description have been met
- [ ] The relevant documentation has been updated:
    - [ ] code comments for classes / methods / complex statements
    - [ ] package readme
    - [ ] documentation for high level approaches or product info
- [ ] Tests:
    - [ ] new tests written
    - [ ] existing affected tests updated
    - [ ] all green and passing
- [ ] Tested by reviewer
